### PR TITLE
accept IO-like object as payload

### DIFF
--- a/lib/webhdfs/client_v1.rb
+++ b/lib/webhdfs/client_v1.rb
@@ -295,9 +295,8 @@ module WebHDFS
       end
 
       res = nil
-      if !payload.nil? and payload.is_a?(IO)
+      if !payload.nil? and payload.respond_to? :read and payload.respond_to? :size
         req = Net::HTTPGenericRequest.new(method,(payload ? true : false),true,request_path,header)
-        raise WebHDFS::IOError, 'Error reading given IO data source' unless payload.respond_to? :read and payload.respond_to? :size
         raise WebHDFS::ClientError, 'Error accepting given IO resource as data payload, Not valid in methods other than PUT and POST' unless (method == 'PUT' or method == 'POST')
 
         req.body_stream = payload


### PR DESCRIPTION
Currently webhdfs gem accepts IO objects as payloads.
This pull request relaxes it so that it accepts IO-like objects (i.e. objects that have read and size methods).

Let me explain why I need this modification.
I want fluent-plugin-webhdfs to support gzip compression.
If webhdfs gem accepts this patch, then I can write the following code:

``` ruby
require 'zlib'
require 'tempfile'
require 'webhdfs'
client = WebHDFS::Client.new("host", 50070)
content = "this is sample"

tmp = Tempfile.new("webhdfs-")
begin
  w = Zlib::GzipWriter.new(tmp)
  w.puts(content)
  w.close
  tmp.close
  tmp.open
  client.create("/path/to/file.gz", tmp)
ensure
  tmp.close(true) rescue nil
end
```
