### PR TITLE
Fix error on kerberos authentication

### DIFF
--- a/lib/webhdfs/client_v1.rb
+++ b/lib/webhdfs/client_v1.rb
@@ -327,7 +327,7 @@ module WebHDFS
         res = conn.send_request(method, request_path, payload, header)
       end
 
-      if @kerberos
+      if @kerberos and res.code == '307'
         itok = (res.header.get_fields('WWW-Authenticate') || ['']).pop.split(/\s+/).last
         unless itok
           raise WebHDFS::KerberosError, 'Server does not return WWW-Authenticate header'


### PR DESCRIPTION
HTTP response header `WWW-Authenticate` only exist with response code==`307`, which return from NameNode. Without this fix, response from DataNode will cause raising exception.