### PR TITLE
Expose GSSAPI::Simple keytab

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Note that [gssapi](https://github.com/zenchild/gssapi) library must be available
 
     client = WebHDFS::Client.new('hostname', 14000)
     client.kerberos = true
+    client.kerberos_keytab = "/path/to/project.keytab"
 
 ## AUTHORS
 

--- a/lib/webhdfs/client_v1.rb
+++ b/lib/webhdfs/client_v1.rb
@@ -23,7 +23,7 @@ module WebHDFS
     attr_accessor :ssl
     attr_accessor :ssl_ca_file
     attr_reader   :ssl_verify_mode
-    attr_accessor :kerberos
+    attr_accessor :kerberos, :kerberos_keytab
 
     SSL_VERIFY_MODES = [:none, :peer]
     def ssl_verify_mode=(mode)
@@ -51,6 +51,7 @@ module WebHDFS
       @ssl_verify_mode = nil
 
       @kerberos = false
+      @kerberos_keytab = nil
     end
 
     # curl -i -X PUT "http://<HOST>:<PORT>/webhdfs/v1/<PATH>?op=CREATE
@@ -303,7 +304,7 @@ module WebHDFS
       if @kerberos
         require 'base64'
         require 'gssapi'
-        gsscli = GSSAPI::Simple.new(@host, 'HTTP')
+        gsscli = GSSAPI::Simple.new(@host, 'HTTP', @kerberos_keytab)
         token = nil
         begin
           token = gsscli.init_context


### PR DESCRIPTION
`GSSAPI::Simple` supports kerberos keytab by [default](https://github.com/zenchild/gssapi/blob/master/lib/gssapi/simple.rb#L23). This PR exposes a client attribute `kerberos_keytab` which defaults to `nil`.

Addresses issue: https://github.com/kzk/webhdfs/issues/15