### PR TITLE
Add more info (host, port) for request exception

### DIFF
--- a/lib/webhdfs/client_v1.rb
+++ b/lib/webhdfs/client_v1.rb
@@ -330,9 +330,17 @@ module WebHDFS
 
         req.body_stream = payload
         req.content_length = payload.size
-        res = conn.request(req)
+        begin
+          res = conn.request(req)
+        rescue => e
+          raise WebHDFS::ServerError, "Failed to connect to host #{host}:#{port}, #{e.message}"
+        end
       else
-        res = conn.send_request(method, request_path, payload, header)
+        begin
+          res = conn.send_request(method, request_path, payload, header)
+        rescue => e
+          raise WebHDFS::ServerError, "Failed to connect to host #{host}:#{port}, #{e.message}"
+        end
       end
 
       if @kerberos and res.code == '307'


### PR DESCRIPTION
This fix #22 which adds more meaning full message like:
```
client_v1.rb:337:in `rescue in request': Failed to connect to host MyHostName:50075, getaddrinfo: Name or service not known (WebHDFS::ServerError)
```