### PR TITLE
Client-cert parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Note that net/https and openssl libraries must be available:
     client.ssl = true
     client.ssl_ca_file = "/path/to/ca_file.pem" # if needed
     client.ssl_varify_mode = :peer # if needed (:none or :peer)
+    client.ssl_version = :TLSv1 # if needed
 
 ### For Kerberos Authentication
 
@@ -103,6 +104,17 @@ Note that [gssapi](https://github.com/zenchild/gssapi) library must be available
     client = WebHDFS::Client.new('hostname', 14000)
     client.kerberos = true
     client.kerberos_keytab = "/path/to/project.keytab"
+
+### For SSL Client Authentication
+
+Note that openssl libraries must be available:
+
+    require 'openssl'
+    
+    client = WebHDFS::Client.new(host, port)
+    client.ssl = true
+    client.ssl_key = OpenSSL::PKey::RSA.new(open('/path/to/key.pem'))
+    client.ssl_cert = OpenSSL::X509::Certificate.new(open('/path/to/cert.pem'))
 
 ## AUTHORS
 

--- a/lib/webhdfs/client_v1.rb
+++ b/lib/webhdfs/client_v1.rb
@@ -23,6 +23,9 @@ module WebHDFS
     attr_accessor :ssl
     attr_accessor :ssl_ca_file
     attr_reader   :ssl_verify_mode
+    attr_accessor :ssl_cert
+    attr_accessor :ssl_key
+    attr_accessor :ssl_version
     attr_accessor :kerberos, :kerberos_keytab
     attr_accessor :http_headers
 
@@ -50,6 +53,9 @@ module WebHDFS
       @ssl = false
       @ssl_ca_file = nil
       @ssl_verify_mode = nil
+      @ssl_cert = nil
+      @ssl_key = nil
+      @ssl_version = nil
 
       @kerberos = false
       @kerberos_keytab = nil
@@ -300,6 +306,9 @@ module WebHDFS
                              when :peer then OpenSSL::SSL::VERIFY_PEER
                              end
         end
+        conn.cert = @ssl_cert if @ssl_cert
+        conn.key = @ssl_key if @ssl_key
+        conn.ssl_version = @ssl_version if @ssl_version
       end
 
       gsscli = nil


### PR DESCRIPTION
This patch adds client-cert and ssl-version parameters of Net::HTTP.

* [cert](http://docs.ruby-lang.org/en/2.2.0/Net/HTTP.html#attribute-i-cert)
* [key](http://docs.ruby-lang.org/en/2.2.0/Net/HTTP.html#attribute-i-key)
* [ssl_version](http://docs.ruby-lang.org/en/2.2.0/Net/HTTP.html#attribute-i-ssl_version)

Usage
---

```
require 'webhdfs'
require 'openssl'

client = WebHDFS::Client.new(localhost, 14000)
client.ssl = true
client.ssl_version = :TLSv1
client.ssl_key = OpenSSL::PKey::RSA.new(open('/path/to/key.pem'))
client.ssl_cert = OpenSSL::X509::Certificate.new(open('/path/to/cert.pem'))
```