### PR TITLE
Add missing licenses - Apache-2.0

### DIFF
--- a/webhdfs.gemspec
+++ b/webhdfs.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |gem|
   gem.files       = Dir['lib/**/*','test/**/*','*.gemspec','*.md','AUTHORS','COPYING','Gemfile','VERSION']
   gem.test_files  = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
+  gem.licenses    = ["Apache-2.0"]
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rdoc"


### PR DESCRIPTION
It is better to add licenses explicitly in gemspec.

  % gem specification webhdfs | \grep licenses
  licenses: []

ref. https://guides.rubygems.org/specification-reference/