### PR TITLE
bugfix when using delegation token

### DIFF
--- a/lib/webhdfs/client_v1.rb
+++ b/lib/webhdfs/client_v1.rb
@@ -82,8 +82,6 @@ module WebHDFS
         @kerberos_token_updated_at = Time.now
       end
       @kerberos_delegation_token
-    rescue => e
-      raise WebHDFS::RequestFailedError, e.message
     end
 
     # curl -i -X PUT "http://<HOST>:<PORT>/webhdfs/v1/<PATH>?op=CREATE


### PR DESCRIPTION
when namenode fail overed, It should follow default exception handler (for fluentd-plugin-webhdfs)

https://github.com/JiHyunSong/webhdfs/blob/bugfix-delegation-token/lib/webhdfs/client_v1.rb#L459-L470

