### PR TITLE
fix base64 unimport error

### DIFF
--- a/lib/webhdfs/client_v1.rb
+++ b/lib/webhdfs/client_v1.rb
@@ -2,7 +2,7 @@ require 'net/http'
 require 'uri'
 require 'json'
 require 'addressable/uri'
-
+require "base64"
 require_relative 'exceptions'
 
 module WebHDFS


### PR DESCRIPTION
when I run testcase and error: WebHDFS::ServerError (Failed to connect to host 10.5.5.235:8199, uninitialized constant WebHDFS::ClientV1::Base64)
<img width="1033" alt="WeChat7ba735e7d3dd8c01a3d6c3a0958b5e36" src="https://user-images.githubusercontent.com/1763449/132288773-6292e650-3cbe-423e-94d8-b503e4061df5.png">
